### PR TITLE
Fixes errors from causing more errors

### DIFF
--- a/lib/hypernova/request_service.rb
+++ b/lib/hypernova/request_service.rb
@@ -9,7 +9,7 @@ class Hypernova::RequestService
     return render_batch_blank(jobs) if jobs.empty?
     response_body = Hypernova::ParsedResponse.new(jobs).body
     response_body.each do |index_string, resp|
-      error(resp["error"], jobs[index_string.to_i]) if resp["error"]
+      on_error(build_error(resp["error"]), jobs[index_string.to_i]) if resp["error"]
     end
     build_renderer(jobs).render(response_body)
   end
@@ -20,15 +20,15 @@ class Hypernova::RequestService
 
   private
 
-  def build_error(name, message)
-    Module.const_get(name).new(message)
+  def build_error(error)
+    {
+      'name' => error['name'],
+      'message' => error['message'],
+      'stack' => error['stack'],
+    }
   end
 
   def build_renderer(jobs)
     Hypernova::BatchRenderer.new(jobs)
-  end
-
-  def error(error_data, job)
-    on_error(build_error(error_data["name"], error_data["message"]), job)
   end
 end

--- a/spec/request_service_spec.rb
+++ b/spec/request_service_spec.rb
@@ -58,11 +58,10 @@ describe Hypernova::RequestService do
           Hypernova.add_plugin!(plugin)
 
           error_from_response = body["1"]["error"]
-          error = Module.const_get(error_from_response["name"]).new(error_from_response["message"])
 
           allow(batch_renderer).to receive(:render).with(body)
 
-          expect(plugin).to receive(:on_error).with(error, jobs[1])
+          expect(plugin).to receive(:on_error).with(error_from_response, jobs[1])
           request_service.render_batch(jobs)
         end
       end


### PR DESCRIPTION
There was an issue with Module.const_get(name) where Rails was throwing
`uninitialized constant Module::Error`. Seems like this is not needed as
we can just pass in the whole error object through to `on_error` so
we'll just keep it simple and do that.

@tommydangerous @ljharb 

Found it: @wyattdanger @mstorus 