### PR TITLE
Assert after_response gets a proper response

### DIFF
--- a/lib/hypernova/batch_renderer.rb
+++ b/lib/hypernova/batch_renderer.rb
@@ -39,9 +39,12 @@ class Hypernova::BatchRenderer
   def render(response)
     fmt_response = response.each_with_object({}) do |array, hash|
       name_of_component = array[0]
-      hash[name_of_component] = extract_html_from_result(name_of_component, array[1])
+      hash[name_of_component] = ensure_has_html(name_of_component, array[1])
     end
-    after_response(fmt_response, response)
+
+    after_response(fmt_response, response).each_with_object({}) do |(name, result), hash|
+      hash[name] = result['html']
+    end
   end
 
   # Example of what is returned by this method:
@@ -59,8 +62,9 @@ class Hypernova::BatchRenderer
 
   attr_reader :jobs
 
-  def extract_html_from_result(name_of_component, result)
-    result["html"].nil? ? render_blank_html(jobs[name_of_component]) : result["html"]
+  def ensure_has_html(name_of_component, result)
+    result['html'] = render_blank_html(jobs[name_of_component]) if result['html'].nil?
+    result
   end
 
   def render_blank_html(job)

--- a/spec/batch_renderer_spec.rb
+++ b/spec/batch_renderer_spec.rb
@@ -36,7 +36,9 @@ describe Hypernova::BatchRenderer do
       class Plugin2
         def after_response(current_response, original_response)
           current_response.merge({
-            force_lightning: true,
+            force_lightning: {
+              'html' => 'palpatine',
+            },
             original_response_2: original_response,
           })
         end
@@ -46,7 +48,7 @@ describe Hypernova::BatchRenderer do
       Hypernova.add_plugin!(plugin_2)
       hash = renderer.render(response)
 
-      expect(hash[:force_lightning]).to eq(true)
+      expect(hash[:force_lightning]).to eq('palpatine')
     end
 
     it "does not have after_response" do


### PR DESCRIPTION
@ljharb @gdborton 

This PR makes sure that `after_response` gets the correct "response"

In 1.0.2 we introduced a bug where `after_response` would receive the "formatted response" which was a hash of tokens => html (string)

`after_response` should be receiving the full response from the Hypernova server, the only difference being that any blank `html` fields should have the fallback client-rendering markup.

With this change we'll now receive the full response, and then we'll go back to doing what we were doing before (creating the hash of tokens => html)