### PR TITLE
Make it compatible for new load API

### DIFF
--- a/lib/hypernova/blank_renderer.rb
+++ b/lib/hypernova/blank_renderer.rb
@@ -7,8 +7,8 @@ class Hypernova::BlankRenderer
 
   def render
     <<-HTML
-      <div data-hypernova-key="#{key}"></div>
-      <script type="application/json" data-hypernova-key="#{key}"><!--#{encode}--></script>
+      <div data-hypernova-key="#{key}" data-hypernova-id="#{id}"></div>
+      <script type="application/json" data-hypernova-key="#{key}" data-hypernova-id="#{id}"><!--#{encode}--></script>
     HTML
   end
 
@@ -30,5 +30,9 @@ class Hypernova::BlankRenderer
 
   def name
     job[:name]
+  end
+
+  def id
+    @id ||= SecureRandom.uuid
   end
 end

--- a/spec/batch_renderer_spec.rb
+++ b/spec/batch_renderer_spec.rb
@@ -25,6 +25,8 @@ describe Hypernova::BatchRenderer do
     end
 
     it "returns a hash with the job name as the key and the HTML as the value" do
+      allow(SecureRandom).to receive(:uuid).and_return("uuid")
+
       hash = renderer.render(response)
 
       expect(hash["a"]).to eq(a_html)
@@ -52,6 +54,8 @@ describe Hypernova::BatchRenderer do
     end
 
     it "does not have after_response" do
+      allow(SecureRandom).to receive(:uuid).and_return("uuid")
+
       class Plugin3
       end
 
@@ -67,6 +71,8 @@ describe Hypernova::BatchRenderer do
 
   describe "#render_blank" do
     it "returns a hash with the job name as the key and blank HTML as the value" do
+      allow(SecureRandom).to receive(:uuid).and_return("uuid")
+
       hash = renderer.render_blank
       expect(hash["a"]).to eq(Hypernova::BlankRenderer.new(jobs["a"]).render)
       expect(hash["b"]).to eq(Hypernova::BlankRenderer.new(jobs["b"]).render)

--- a/spec/blank_renderer_spec.rb
+++ b/spec/blank_renderer_spec.rb
@@ -14,8 +14,19 @@ describe Hypernova::BlankRenderer do
     end
 
     it "renders blank html" do
+      allow(SecureRandom).to receive(:uuid).and_return("uuid")
+
       html = described_class.new(job).render
       expect(html).to eq(blank_html(job))
+    end
+
+    it "uses the same id for the div and the script tag" do
+      blank_renderer = described_class.new(job)
+      html = blank_renderer.render
+      id = blank_renderer.send(:id)
+
+      expect(html).to match(/<div.*data-hypernova-id="#{id}"/)
+      expect(html).to match(/<script.*data-hypernova-id="#{id}"/)
     end
 
     it "encodes data correctly" do
@@ -37,11 +48,12 @@ describe Hypernova::BlankRenderer do
     data = job[:data]
     name = job[:name]
     key = name.gsub(/\W/, "")
+    id = "uuid"
     json_data = described_class.new(job).send(:encode)
 
     <<-HTML
-      <div data-hypernova-key="#{key}"></div>
-      <script type="application/json" data-hypernova-key="#{key}"><!--#{json_data}--></script>
+      <div data-hypernova-key="#{key}" data-hypernova-id="#{id}"></div>
+      <script type="application/json" data-hypernova-key="#{key}" data-hypernova-id="#{id}"><!--#{json_data}--></script>
     HTML
   end
 end


### PR DESCRIPTION
Since we change `load` API in hypernova 2.0.0, we need update `blank_render` to make it compatible when node server is down.
