### PR TITLE
[dev] display stack trace in monospace

### DIFF
--- a/lib/hypernova/plugins/development_mode_plugin.rb
+++ b/lib/hypernova/plugins/development_mode_plugin.rb
@@ -1,3 +1,5 @@
+require 'erb'
+
 class DevelopmentModePlugin
   def after_response(current_response, _)
     current_response.each do |name, result|
@@ -12,14 +14,28 @@ class DevelopmentModePlugin
       <div style="background-color: #ff5a5f; color: #fff; padding: 12px;">
         <p style="margin: 0">
           <strong>Development Warning!</strong>
-          The <code>#{name}</code> component failed to render with Hypernova. Error stack:
+          The <code>#{html_escape(name)}</code> component failed to render with Hypernova. Error stack:
         </p>
-        <ul style="padding: 0 20px">
-          <li>#{stack_trace(result).join("</li><li>")}</li>
-        </ul>
+	#{ render_stack_trace(stack_trace(result)) }
       </div>
       #{result["html"]}
     HTML
+  end
+
+  def render_stack_trace(trace)
+    # Put trace that was split in Hypernova back together, verbatim. Sometimes
+    # splitting babel errors makes them more confusing.
+    # https://github.com/airbnb/hypernova/blob/master/src/utils/BatchManager.js
+    text = html_escape(trace.join("\n    "))
+    <<-HTML
+      <div
+        style="white-space: pre-wrap; font-family: monospace; font-size: .95em;"
+      >#{text}</div>
+    HTML
+  end
+
+  def html_escape(string)
+    ::ERB::Util.html_escape(string)
   end
 
   def stack_trace(result)

--- a/spec/controller_helpers_spec.rb
+++ b/spec/controller_helpers_spec.rb
@@ -131,12 +131,7 @@ describe Hypernova::ControllerHelpers do
         end
 
         stub_request(:post, "http://mordor.com:1337/batch").
-          with(:body => "{\"0\":{\"name\":\"mordor.js\",\"data\":{}}}",
-               :headers => {
-                 'Accept'=>'*/*',
-                 'Content-Type'=>'application/json',
-                 'User-Agent'=>'Faraday v0.10.1'
-               }).
+          with(:body => "{\"0\":{\"name\":\"mordor.js\",\"data\":{}}}").
           to_return(:status => 200, :body => '{}', :headers => {})
 
         test = TestClass.new


### PR DESCRIPTION
Babel and other compilers omit nice error messages, but those messages
rely on the pre-wrap spacing behavior of a monospaced terminal.

This commit changes the development mode plugin to emit stacks in a
pre-like block. It also html_escapes the stack trace to prevent strange rendering errors that sometimes occur if the error contains `<html>`.

![screenshot](https://monosnap.com/file/ZcEeI0L8Qu9x1q7FnBFGhm94Zx0IRM.png)

@ljharb @gdborton @goatslacker 