### PR TITLE
Update CHANGELOG.md for #11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Developer plugin will now display Hypernova error stack traces in monospaced font, instead of as list items. HTML-escape stack traces.
+
 ## [1.1.0] - 2016-11-10
 
 ### Added


### PR DESCRIPTION
From #11:

> Babel and other compilers omit nice error messages, but those messages
> rely on the pre-wrap spacing behavior of a monospaced terminal.

> This commit changes the development mode plugin to emit stacks in a
> pre-like block. It also html_escapes the stack trace to prevent strange
> rendering errors that sometimes occur if the error contains <html>.