### PR TITLE
Pass hash into on_error

### DIFF
--- a/lib/hypernova/controller_helpers.rb
+++ b/lib/hypernova/controller_helpers.rb
@@ -88,7 +88,7 @@ module Hypernova
           result = @hypernova_batch.submit!
           on_success(result, hash)
         rescue StandardError => e
-          on_error(e)
+          on_error(e, {}, hash)
           result = @hypernova_batch.submit_fallback!
         end
       else

--- a/lib/hypernova/controller_helpers.rb
+++ b/lib/hypernova/controller_helpers.rb
@@ -88,7 +88,7 @@ module Hypernova
           result = @hypernova_batch.submit!
           on_success(result, hash)
         rescue StandardError => e
-          on_error(e, {}, hash)
+          on_error(e, nil, hash)
           result = @hypernova_batch.submit_fallback!
         end
       else

--- a/lib/hypernova/plugin_helper.rb
+++ b/lib/hypernova/plugin_helper.rb
@@ -47,8 +47,8 @@ module Hypernova::PluginHelper
     end
   end
 
-  def on_error(error, job = {})
-    Hypernova.plugins.each { |plugin| plugin.on_error(error, job) if plugin.respond_to?(:on_error) }
+  def on_error(error, job = nil, jobs_hash = nil)
+    Hypernova.plugins.each { |plugin| plugin.on_error(error, job, jobs_hash) if plugin.respond_to?(:on_error) }
   end
 
   def on_success(res, jobs_hash)

--- a/spec/batch_renderer_spec.rb
+++ b/spec/batch_renderer_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "hypernova/batch_renderer"
+require "securerandom"
 
 describe Hypernova::BatchRenderer do
   # Do not override these variables

--- a/spec/controller_helpers_spec.rb
+++ b/spec/controller_helpers_spec.rb
@@ -109,7 +109,7 @@ describe Hypernova::ControllerHelpers do
         allow(test).to receive(:will_send_request).and_raise(error)
         allow(test).to receive(:response).and_return(response)
 
-        expect(test).to receive(:on_error).with(error)
+        expect(test).to receive(:on_error).with(error, hash_including(), hash_including('mordor.js'))
         expect(batch).to receive(:submit_fallback!)
 
         test.hypernova_render_support {}

--- a/spec/controller_helpers_spec.rb
+++ b/spec/controller_helpers_spec.rb
@@ -109,7 +109,7 @@ describe Hypernova::ControllerHelpers do
         allow(test).to receive(:will_send_request).and_raise(error)
         allow(test).to receive(:response).and_return(response)
 
-        expect(test).to receive(:on_error).with(error, hash_including(), hash_including('mordor.js'))
+        expect(test).to receive(:on_error).with(error, nil, hash_including('mordor.js'))
         expect(batch).to receive(:submit_fallback!)
 
         test.hypernova_render_support {}

--- a/spec/plugin_helper_spec.rb
+++ b/spec/plugin_helper_spec.rb
@@ -31,7 +31,7 @@ describe Hypernova::PluginHelper do
   describe "#on_error" do
     it "calls on_error for each plugin" do
       class Plugin
-        def on_error(error, job)
+        def on_error(error, job, jobs_hash)
         end
       end
 
@@ -40,9 +40,10 @@ describe Hypernova::PluginHelper do
 
       error = double("error")
       job = double("job")
+      jobs_hash = double("jobs")
 
-      expect(plugin).to receive(:on_error).with(error, job)
-      TestClass.new.on_error(error, job)
+      expect(plugin).to receive(:on_error).with(error, job, jobs_hash)
+      TestClass.new.on_error(error, job, jobs_hash)
     end
   end
 

--- a/spec/request_service_spec.rb
+++ b/spec/request_service_spec.rb
@@ -49,8 +49,8 @@ describe Hypernova::RequestService do
 
         it "calls on_error for each job where the response has an error with a new hash" do
           class Plugin
-            def on_error(error, job)
-              [error.message, job]
+            def on_error(error, job, jobs_hash)
+              [error.message, job, jobs_hash]
             end
           end
 
@@ -61,7 +61,7 @@ describe Hypernova::RequestService do
 
           allow(batch_renderer).to receive(:render).with(body)
 
-          expect(plugin).to receive(:on_error).with(error_from_response, jobs[1])
+          expect(plugin).to receive(:on_error).with(error_from_response, jobs[1], nil)
           request_service.render_batch(jobs)
         end
       end


### PR DESCRIPTION
@goatslacker this is necessary to be able to inspect jobs from within a plugin's `on_error` method