### PR TITLE
fix: render_batch receives jobs in hash form.

### DIFF
--- a/lib/hypernova/request_service.rb
+++ b/lib/hypernova/request_service.rb
@@ -9,7 +9,7 @@ class Hypernova::RequestService
     return render_batch_blank(jobs) if jobs.empty?
     response_body = Hypernova::ParsedResponse.new(jobs).body
     response_body.each do |index_string, resp|
-      on_error(build_error(resp["error"]), jobs[index_string.to_i]) if resp["error"]
+      on_error(build_error(resp["error"]), jobs[index_string]) if resp["error"]
     end
     build_renderer(jobs).render(response_body)
   end

--- a/spec/request_service_spec.rb
+++ b/spec/request_service_spec.rb
@@ -17,10 +17,10 @@ describe Hypernova::RequestService do
       # Do not override these variables
       let(:batch_renderer) { double("batch_renderer") }
       let(:jobs) do
-        [
-          Helpers.args_1,
-          Helpers.args_2,
-        ]
+        {
+          "0" => Helpers.args_1,
+          "1" => Helpers.args_2,
+        }
       end
       let(:parsed_response) { double("parsed_response", body: body) }
 
@@ -61,7 +61,7 @@ describe Hypernova::RequestService do
 
           allow(batch_renderer).to receive(:render).with(body)
 
-          expect(plugin).to receive(:on_error).with(error_from_response, jobs[1], nil)
+          expect(plugin).to receive(:on_error).with(error_from_response, jobs["1"], nil)
           request_service.render_batch(jobs)
         end
       end


### PR DESCRIPTION
All occurrences of RequestService's `render_batch` receive their jobs input
in hash form but were expecting it to be an array.
This caused the on_error callbacks to always silently get called with a
nil job.

Since the consistent form of arguments to the RequestService's methods is a hash,
the mock jobs in its test are also wrapped in a hash ( instead of an
array ).