### PR TITLE
Updated README add third param to plugin on_error example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ class HypernovaPlugin
   end
 
   # NOTE: If an error happens in here, it won’t be caught.
-  def on_error(error, jobs)
-    puts "Oh no, error - #{error}, jobs - #{jobs}"
+  def on_error(error, jobs, jobs_hash)
+    puts "Oh no, error - #{error}, jobs - #{jobs}, jobs_hash - #{jobs_hash}"
   end
 end
 


### PR DESCRIPTION
Updated README for that version 1.3.0 added third param to plugin on_error.
https://github.com/airbnb/hypernova-ruby/blob/master/CHANGELOG.md#added