### PR TITLE
Enable plugins to support multiple renderings of same component

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ class HypernovaPlugin
   # prepare_request allows you to alter the request object in any way that you
   # need.
   # Unless manipulated by another plugin, request takes the shape:
-  # { 'component_name.js': { :name => 'component_name.js', :data => {} } }
+  # [{ :name => 'component_name.js', :data => {} }, ...]
   def prepare_request(current_request, original_request)
     current_request.keys.each do |key|
       phrase_hash = req[key][:data][:phrases]

--- a/lib/hypernova/controller_helpers.rb
+++ b/lib/hypernova/controller_helpers.rb
@@ -78,17 +78,15 @@ module Hypernova
       return if @hypernova_batch.empty?
 
       jobs = @hypernova_batch.jobs
-      hash = jobs.each_with_object({}) do |job, h|
-        h[job[:name]] = job
-      end
-      hash = prepare_request(hash, hash)
-      if send_request?(hash)
+      jobs = prepare_request(jobs, jobs)
+
+      if send_request?(jobs)
         begin
-          will_send_request(hash)
+          will_send_request(jobs)
           result = @hypernova_batch.submit!
-          on_success(result, hash)
+          on_success(result, jobs)
         rescue StandardError => e
-          on_error(e, nil, hash)
+          on_error(e, nil, jobs)
           result = @hypernova_batch.submit_fallback!
         end
       else

--- a/lib/hypernova/plugin_helper.rb
+++ b/lib/hypernova/plugin_helper.rb
@@ -19,20 +19,20 @@ module Hypernova::PluginHelper
     end
   end
 
-  def send_request?(jobs_hash)
+  def send_request?(jobs)
     Hypernova.plugins.all? do |plugin|
       if plugin.respond_to?(:send_request?)
-        plugin.send_request?(jobs_hash)
+        plugin.send_request?(jobs)
       else
         true
       end
     end
   end
 
-  def will_send_request(jobs_hash)
+  def will_send_request(jobs)
     Hypernova.plugins.each do |plugin|
       if plugin.respond_to?(:will_send_request)
-        plugin.will_send_request(jobs_hash)
+        plugin.will_send_request(jobs)
       end
     end
   end
@@ -47,13 +47,13 @@ module Hypernova::PluginHelper
     end
   end
 
-  def on_error(error, job = nil, jobs_hash = nil)
-    Hypernova.plugins.each { |plugin| plugin.on_error(error, job, jobs_hash) if plugin.respond_to?(:on_error) }
+  def on_error(error, job = nil, jobs = nil)
+    Hypernova.plugins.each { |plugin| plugin.on_error(error, job, jobs) if plugin.respond_to?(:on_error) }
   end
 
-  def on_success(res, jobs_hash)
+  def on_success(res, jobs)
     Hypernova.plugins.each do |plugin|
-      plugin.on_success(res, jobs_hash) if plugin.respond_to?(:on_success)
+      plugin.on_success(res, jobs) if plugin.respond_to?(:on_success)
     end
   end
 end

--- a/spec/controller_helpers_spec.rb
+++ b/spec/controller_helpers_spec.rb
@@ -109,7 +109,7 @@ describe Hypernova::ControllerHelpers do
         allow(test).to receive(:will_send_request).and_raise(error)
         allow(test).to receive(:response).and_return(response)
 
-        expect(test).to receive(:on_error).with(error, nil, array_including(hash_including({name: "mordor.js"})))
+        expect(test).to receive(:on_error).with(error, nil, array_including(hash_including({ :name => "mordor.js" })))
         expect(batch).to receive(:submit_fallback!)
 
         test.hypernova_render_support {}

--- a/spec/controller_helpers_spec.rb
+++ b/spec/controller_helpers_spec.rb
@@ -109,7 +109,7 @@ describe Hypernova::ControllerHelpers do
         allow(test).to receive(:will_send_request).and_raise(error)
         allow(test).to receive(:response).and_return(response)
 
-        expect(test).to receive(:on_error).with(error, nil, hash_including('mordor.js'))
+        expect(test).to receive(:on_error).with(error, nil, array_including(hash_including({name: "mordor.js"})))
         expect(batch).to receive(:submit_fallback!)
 
         test.hypernova_render_support {}
@@ -137,14 +137,14 @@ describe Hypernova::ControllerHelpers do
         test = TestClass.new
         batch = Hypernova::Batch.new(test.hypernova_service)
         response = TestResponse.new
-        jobs = { name: "mordor.js", data: {} }
+        job = { name: "mordor.js", data: {} }
 
-        batch.render(jobs)
+        batch.render(job)
 
         allow(Hypernova::Batch).to receive(:new).with(test.hypernova_service).and_return(batch)
         allow(test).to receive(:response).and_return(response)
 
-        expect(test).to receive(:on_success).with({}, { "mordor.js" => jobs })
+        expect(test).to receive(:on_success).with({}, [job])
 
         test.hypernova_render_support {}
       end
@@ -282,19 +282,19 @@ describe Hypernova::ControllerHelpers do
     describe "prepare_request plugins" do
       class PrepareRequestPlugin
         def prepare_request(current_request, _)
-          current_request['test'][:data][:what] = 'who?'
+          current_request[0][:data][:what] = 'who?'
         end
       end
 
       it 'should be able to alter the request data' do
         plugin = PrepareRequestPlugin.new
         Hypernova.add_plugin!(plugin)
-        request = {
-          'test' => {
+        request = [
+          {
             :name => 'test',
             :data => request_data,
           },
-        }
+        ]
         expect(plugin).to receive(:prepare_request).with(request, request).and_call_original
         expect(full_controller.hypernova_service).to receive(:render_batch).with({
           '0' => {

--- a/spec/controller_helpers_spec.rb
+++ b/spec/controller_helpers_spec.rb
@@ -137,7 +137,7 @@ describe Hypernova::ControllerHelpers do
         test = TestClass.new
         batch = Hypernova::Batch.new(test.hypernova_service)
         response = TestResponse.new
-        job = { name: "mordor.js", data: {} }
+        job = { :name => "mordor.js", :data => {} }
 
         batch.render(job)
 


### PR DESCRIPTION
The current implementation of the plugins feature passes a hash of hypernova-jobs to the callbacks 
(e.g. `{ 'component_name.js': { :name => 'component_name.js', :data => {} } }`).
This makes it impossible to render a single component more than once per request when using plugins, although hypernova supports it by default.

This PR changes this behavior and passes the jobs array from `hypernova_batch` to the plugin functions, so all jobs can be process equally.
(e.g. `[{ :name => 'component_name.js', :data => {} }, ...]`).

I changed the version to `2.0.0` since this is a breaking change for everyone who is using plugins that use `prepare_request`, `send_request?`, `will_send_request`, `on_success` or `on_error` since they all receive an array instead of hash now.