### PR TITLE
Relieve the version requirements of faraday gem to use faraday-1.x 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ build/
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
 Gemfile.lock
+gemfiles/*.lock
 # .ruby-version
 # .ruby-gemset
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,17 @@ rvm:
 gemfile:
   - gemfiles/faraday-0.8.gemfile
   - gemfiles/faraday-1.0.gemfile
+matrix:
+  fast_finish: true
+  allow_failures:
+    - gemfile: gemfiles/faraday-1.0.gemfile
+      rvm: "1.9.3"
+    - gemfile: gemfiles/faraday-1.0.gemfile
+      rvm: "2.0"
+    - gemfile: gemfiles/faraday-1.0.gemfile
+      rvm: "2.1"
+    - gemfile: gemfiles/faraday-1.0.gemfile
+      rvm: "2.2"
 before_install:
   - gem update bundler
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ rvm:
   - "2.5"
   - "2.6"
   - "2.7"
+gemfile:
+  - gemfiles/faraday-0.8.gemfile
+  - gemfiles/faraday-1.0.gemfile
 before_install:
   - gem update bundler
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,11 @@ rvm:
   - "2.0"
   - "2.1"
   - "2.2"
-  - "2.3.3"
+  - "2.3"
+  - "2.4"
+  - "2.5"
+  - "2.6"
+  - "2.7"
 before_install:
   - gem update bundler
 script:

--- a/gemfiles/faraday-0.8.gemfile
+++ b/gemfiles/faraday-0.8.gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'faraday', '~> 0.8'
+gemspec path: '../'

--- a/gemfiles/faraday-1.0.gemfile
+++ b/gemfiles/faraday-1.0.gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'faraday', '~> 1.0'
+gemspec path: '../'

--- a/hypernova.gemspec
+++ b/hypernova.gemspec
@@ -39,6 +39,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "~> 0.11"
   spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "webmock", "= 2.3.2"
+  # crack gem added REXML to its dependency at v0.4.5, but it causes an error when used on Ruby 1.9
+  spec.add_development_dependency "crack", "< 0.4.5"
   # below works around travis-ci requiring github-pages-health-check, whose subdep public_suffix
   # stopped being compatible with ruby 1.9
   # see https://github.com/weppos/publicsuffix-ruby/issues/127

--- a/hypernova.gemspec
+++ b/hypernova.gemspec
@@ -44,5 +44,5 @@ Gem::Specification.new do |spec|
   # see https://github.com/weppos/publicsuffix-ruby/issues/127
   spec.add_development_dependency "public_suffix", "=1.4.6"
 
-  spec.add_runtime_dependency "faraday", "~> 0.8"
+  spec.add_runtime_dependency "faraday", ">= 0.8"
 end

--- a/hypernova.gemspec
+++ b/hypernova.gemspec
@@ -38,9 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "simplecov", "~> 0.11"
   spec.add_development_dependency "pry", "~> 0.10"
-  # this is pinned because ruby devs hate semver
-  # see https://github.com/bblimke/webmock/issues/667
-  spec.add_development_dependency "webmock", "=2.1.0"
+  spec.add_development_dependency "webmock", "= 2.3.2"
   # below works around travis-ci requiring github-pages-health-check, whose subdep public_suffix
   # stopped being compatible with ruby 1.9
   # see https://github.com/weppos/publicsuffix-ruby/issues/127

--- a/spec/faraday_connection_spec.rb
+++ b/spec/faraday_connection_spec.rb
@@ -21,7 +21,11 @@ describe Hypernova::FaradayConnection do
         }).
         and_call_original
 
-      expect(described_class.build.builder.handlers).to include(Faraday::Adapter::NetHttp)
+      if Gem.loaded_specs['faraday'].version >= Gem::Version.new("1.0.0")
+        expect(described_class.build.builder.adapter).to eq(Faraday::Adapter::NetHttp)
+      else
+        expect(described_class.build.builder.handlers).to include(Faraday::Adapter::NetHttp)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR contains these changes.

* Relieve the version specification on faraday gem in order to use it with v1.x.
    * webmock gem is also updated to fix an incompatibility with faraday v1.x
* Add test targets(Ruby 2.4, 2.5, 2.6, 2.7)

## Concerns

Migrating faraday 0.8 to 1.x has significant breaking changes. 
ref: https://github.com/lostisland/faraday/blob/master/UPGRADING.md#faraday-10

Should we upgrade hypernova-ruby to 2.0?
If so, I think we can drop support for old Ruby versions reached to EOL for easy maintenance.
For instance, json-1.8 gem which hypernova-ruby uses produces a deprecated warning on Ruby 2.7. But json-2.x doesn't support Ruby 1.9.
ref: https://github.com/flori/json/blob/v2.5.1/json.gemspec#L68