### PR TITLE
Update to Faraday 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,9 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - "1.9.3"
-  - "2.0"
-  - "2.1"
-  - "2.2"
-  - "2.3.3"
+  - "2.5"
+  - "2.6"
+  - "2.7"
 before_install:
   - gem update bundler
 script:

--- a/hypernova.gemspec
+++ b/hypernova.gemspec
@@ -46,5 +46,5 @@ Gem::Specification.new do |spec|
   # see https://github.com/weppos/publicsuffix-ruby/issues/127
   spec.add_development_dependency "public_suffix", "=1.4.6"
 
-  spec.add_runtime_dependency "faraday", "~> 0.8"
+  spec.add_runtime_dependency "faraday", "~> 1"
 end

--- a/hypernova.gemspec
+++ b/hypernova.gemspec
@@ -38,9 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "simplecov", "~> 0.11"
   spec.add_development_dependency "pry", "~> 0.10"
-  # this is pinned because ruby devs hate semver
-  # see https://github.com/bblimke/webmock/issues/667
-  spec.add_development_dependency "webmock", "=2.1.0"
+  spec.add_development_dependency "webmock", "~> 3.0"
   # below works around travis-ci requiring github-pages-health-check, whose subdep public_suffix
   # stopped being compatible with ruby 1.9
   # see https://github.com/weppos/publicsuffix-ruby/issues/127

--- a/hypernova.gemspec
+++ b/hypernova.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
     spec.metadata["allowed_push_host"] = 'https://rubygems.org'
   end
 
-  spec.add_development_dependency "json", "~> 1.8"
+  spec.add_development_dependency "json"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "simplecov", "~> 0.11"

--- a/hypernova.gemspec
+++ b/hypernova.gemspec
@@ -39,10 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "~> 0.11"
   spec.add_development_dependency "pry", "~> 0.10"
   spec.add_development_dependency "webmock", "~> 3.0"
-  # below works around travis-ci requiring github-pages-health-check, whose subdep public_suffix
-  # stopped being compatible with ruby 1.9
-  # see https://github.com/weppos/publicsuffix-ruby/issues/127
-  spec.add_development_dependency "public_suffix", "=1.4.6"
 
   spec.add_runtime_dependency "faraday", "~> 1"
 end

--- a/spec/faraday_connection_spec.rb
+++ b/spec/faraday_connection_spec.rb
@@ -21,7 +21,7 @@ describe Hypernova::FaradayConnection do
         }).
         and_call_original
 
-      expect(described_class.build.builder.handlers).to include(Faraday::Adapter::NetHttp)
+      expect(described_class.build.builder.adapter).to eq(Faraday::Adapter::NetHttp)
     end
   end
 end


### PR DESCRIPTION
As the PR #27 I sent a before, Migrating Faraday to 1.x has significant changes.
So, I suggest to update the old dependencies and the supported Ruby versions in order to meet the recent development circumstances.

I think this gem is great, but it blocks updating the other gems which dependent to Faraday in my projects.

This change needs a major update, would you consider it?

ref: https://github.com/lostisland/faraday/blob/master/UPGRADING.md