### PR TITLE
v2.0.0 Official deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0] - 2023-10-06
+
+Official deprecation.
+
 ## [1.4.0] - 2019-01-24
 
 ### Fixed

--- a/hypernova.gemspec
+++ b/hypernova.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
     'Josh Perez'
   ]
   spec.bindir = "exe"
-  spec.description = "A Ruby client for the Hypernova service"
+  spec.description = "[deprecated] A Ruby client for the Hypernova service"
   spec.email = %w(
     jake.tl@airbnb.com
     ljharb@gmail.com
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
 
   if spec.respond_to?(:metadata)
     spec.metadata["allowed_push_host"] = 'https://rubygems.org'
+    spec.metadata['deprecated'] = 'true'
   end
 
   spec.add_development_dependency "json", "~> 1.8"

--- a/lib/hypernova.rb
+++ b/lib/hypernova.rb
@@ -3,6 +3,8 @@ require "hypernova/configuration"
 require "hypernova/rails/action_controller"
 require "hypernova/version"
 
+warn "[DEPRECATION] The 'hypernova' gem has been deprecated."
+
 module Hypernova
   # thrown by ControllerHelper methods if you don't call hypernova_batch_before first
   class NilBatchError < StandardError; end

--- a/lib/hypernova/version.rb
+++ b/lib/hypernova/version.rb
@@ -1,3 +1,3 @@
 module Hypernova
-  VERSION = "1.4.0"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
Deprecation is considered a breaking change.

### How was this tested?

Followed instructions [here](https://guides.rubygems.org/make-your-own-gem/).

```
$ gem build
  Successfully built RubyGem
  Name: hypernova
  Version: 2.0.0
  File: hypernova-2.0.0.gem

$ gem install ./hypernova-2.0.0.gem 
Successfully installed hypernova-2.0.0
Parsing documentation for hypernova-2.0.0
Done installing documentation for hypernova after 0 seconds
1 gem installed

$ irb
irb(main):001:0> require "hypernova"
[DEPRECATION] The 'hypernova' gem has been deprecated.
=> true
irb(main):002:0> 
```

```
bundle exec rspec
...
Finished in 0.06111 seconds (files took 0.83804 seconds to load)
72 examples, 0 failures
```